### PR TITLE
Fixes autolathe pulling you back into the menu after making an item

### DIFF
--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -522,7 +522,6 @@
 	being_built = null
 	icon_state = "autolathe"
 	busy = FALSE
-	updateDialog()
 
 /obj/machinery/autolathe/RefreshParts()
 	var/T = 0


### PR DESCRIPTION
## About The Pull Request

See above

## Why It's Good For The Game

This was incredibly annoying

## Changelog
:cl:
fix: fixes autolathe pulling you back into the autolathe menu after printing an item
/:cl: