### PR TITLE
Add RCD wall suicide

### DIFF
--- a/code/game/objects/items/RCD.dm
+++ b/code/game/objects/items/RCD.dm
@@ -209,10 +209,10 @@ RLD
 	var/turf/T = get_turf(user)
 
 	if(isopenturf(T) && checkResource(16, user)) // It takes 16 resources to construct a wall
-		user.visible_message("<span class='suicide'>[user] sets the RCD to 'Wall' and points it down [user.p_their()] throat! It looks like [user.p_theyre()] trying to commit suicide..</span>")
+		user.visible_message("<span class='suicide'>[user] sets the RCD to 'Wall' and points it down [user.p_their()] throat! It looks like [user.p_theyre()] trying to commit suicide!</span>")
 		T.rcd_act(user, src, RCD_FLOORWALL)
 		T = get_turf(user)
-		if(isopenturf(T)) // If RCD didn't place a wall (if it placed a floor this will place the the wall)
+		if(isopenturf(T)) // If the RCD didn't place a wall (if it placed a floor this will place a wall)
 			T.rcd_act(user, src, RCD_FLOORWALL)
 		user.gib()
 		useResource(16, user)

--- a/code/game/objects/items/RCD.dm
+++ b/code/game/objects/items/RCD.dm
@@ -204,15 +204,19 @@ RLD
 	var/delay_mod = 1
 	var/canRturf = FALSE //Variable for R walls to deconstruct them
 
-/obj/item/construction/rcd/suicide_act(mob/user)
-	mode = RCD_FLOORWALL
+/obj/item/construction/rcd/suicide_act(mob/living/user)
 	var/turf/T = get_turf(user)
 
-	if(isopenturf(T) && checkResource(16, user)) // It takes 16 resources to construct a wall
-		user.visible_message("<span class='suicide'>[user] sets the RCD to 'Wall' and points it down [user.p_their()] throat! It looks like [user.p_theyre()] trying to commit suicide!</span>")
+	if(!isopenturf(T)) // Oh fuck
+		user.visible_message("<span class='suicide'>[user] is beating [user.p_them()]self to death with [src]! It looks like [user.p_theyre()] trying to commit suicide!</span>")
+		return BRUTELOSS
+
+	mode = RCD_FLOORWALL
+	user.visible_message("<span class='suicide'>[user] sets the RCD to 'Wall' and points it down [user.p_their()] throat! It looks like [user.p_theyre()] trying to commit suicide!</span>")
+	if(checkResource(16, user)) // It takes 16 resources to construct a wall
 		var/success = T.rcd_act(user, src, RCD_FLOORWALL)
 		T = get_turf(user)
-		// If the RCD placed a floor instead of a wall; having a wall without plating under it is cursed
+		// If the RCD placed a floor instead of a wall, having a wall without plating under it is cursed
 		// There isn't an easy programmatical way to check if rcd_act will place a floor or a wall, so just repeat using it for free
 		if(success && isopenturf(T))
 			T.rcd_act(user, src, RCD_FLOORWALL)
@@ -222,8 +226,8 @@ RLD
 		user.gib()
 		return MANUAL_SUICIDE
 
-	user.visible_message("<span class='suicide'>[user] is beating [user.p_them()]self to death with [src]! It looks like [user.p_theyre()] trying to commit suicide!</span>")
-	return BRUTELOSS
+	user.visible_message("<span class='suicide'>[user] pulls the trigger... But there is not enough ammo!</span>")
+	return SHAME
 
 /obj/item/construction/rcd/verb/toggle_window_type_verb()
 	set name = "RCD : Toggle Window Type"

--- a/code/game/objects/items/RCD.dm
+++ b/code/game/objects/items/RCD.dm
@@ -210,18 +210,20 @@ RLD
 
 	if(isopenturf(T) && checkResource(16, user)) // It takes 16 resources to construct a wall
 		user.visible_message("<span class='suicide'>[user] sets the RCD to 'Wall' and points it down [user.p_their()] throat! It looks like [user.p_theyre()] trying to commit suicide!</span>")
-		T.rcd_act(user, src, RCD_FLOORWALL)
+		var/success = T.rcd_act(user, src, RCD_FLOORWALL)
 		T = get_turf(user)
-		if(isopenturf(T)) // If the RCD didn't place a wall (if it placed a floor this will place a wall)
+		// If the RCD placed a floor instead of a wall; having a wall without plating under it is cursed
+		// There isn't an easy programmatical way to check if rcd_act will place a floor or a wall, so just repeat using it for free
+		if(success && isopenturf(T))
 			T.rcd_act(user, src, RCD_FLOORWALL)
-		user.gib()
 		useResource(16, user)
 		activate()
 		playsound(src.loc, 'sound/machines/click.ogg', 50, 1)
-	else
-		user.visible_message("<span class='suicide'>[user] is beating [user.p_them()]self to death with [src]! It looks like [user.p_theyre()] trying to commit suicide!</span>")
+		user.gib()
+		return MANUAL_SUICIDE
 
-	return (BRUTELOSS)
+	user.visible_message("<span class='suicide'>[user] is beating [user.p_them()]self to death with [src]! It looks like [user.p_theyre()] trying to commit suicide!</span>")
+	return BRUTELOSS
 
 /obj/item/construction/rcd/verb/toggle_window_type_verb()
 	set name = "RCD : Toggle Window Type"

--- a/code/game/objects/items/RCD.dm
+++ b/code/game/objects/items/RCD.dm
@@ -205,7 +205,22 @@ RLD
 	var/canRturf = FALSE //Variable for R walls to deconstruct them
 
 /obj/item/construction/rcd/suicide_act(mob/user)
-	user.visible_message("<span class='suicide'>[user] sets the RCD to 'Wall' and points it down [user.p_their()] throat! It looks like [user.p_theyre()] trying to commit suicide..</span>")
+	mode = RCD_FLOORWALL
+	var/turf/T = get_turf(user)
+
+	if(isopenturf(T) && checkResource(16, user)) // It takes 16 resources to construct a wall
+		user.visible_message("<span class='suicide'>[user] sets the RCD to 'Wall' and points it down [user.p_their()] throat! It looks like [user.p_theyre()] trying to commit suicide..</span>")
+		T.rcd_act(user, src, RCD_FLOORWALL)
+		T = get_turf(user)
+		if(isopenturf(T)) // If RCD didn't place a wall (if it placed a floor this will place the the wall)
+			T.rcd_act(user, src, RCD_FLOORWALL)
+		user.gib()
+		useResource(16, user)
+		activate()
+		playsound(src.loc, 'sound/machines/click.ogg', 50, 1)
+	else
+		user.visible_message("<span class='suicide'>[user] is beating [user.p_them()]self to death with [src]! It looks like [user.p_theyre()] trying to commit suicide!</span>")
+
 	return (BRUTELOSS)
 
 /obj/item/construction/rcd/verb/toggle_window_type_verb()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Using the suicide verb with the RCD now actually spawns a wall to gib you if it has enough ammo for a wall, otherwise you'll beat yourself to death with it.

## Why It's Good For The Game

Wall vore

## Changelog
:cl:
tweak: Suiciding with the RCD now spawns a wall and gibs you
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
